### PR TITLE
Update packages and fix rpath. Fix version of build image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,24 +40,6 @@ AWS SAM needs to be installed first.
 The install of SAM under Ubuntu isn't totally straightforward. The install
 instructions are here: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html
 
-These instructions seem to indicate that installing SAM globally on the machine
-works. However, we have discovered that this appears to 
-introduce a problem where the `LD_LIBRARY_PATH` in the test Lambda function is set 
-incorrectly. There is now an assert in the test function to catch this situation.
-
-We instead recommend that SAM is installed into a Python virtual env as shown below:
-
-```
-python3 -m venv .sam_venv
-source .sam_venv/bin/activate
-wget https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-arm64.zip
-unzip aws-sam-cli-linux-arm64.zip
-cd aws-sam-cli-src
-pip install .
-```
-
-You will need to activate this virtual env each time you wish to work on cibo_tilerlayer.
-
 ### Testing
 
 NOTE: if you get a 'port in use' error when running `test-deploy.py`, run ::
@@ -105,12 +87,7 @@ and bump the version here too.
 
 ### Environment Variables
 
-In client Lambdas, to be able to find the shared libraries the `LD_LIBRARY_PATH` should be set 
-in the Environment/Variables section like this::
-
-    LD_LIBRARY_PATH: "/opt/python/lib:/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/opt/lib"
-
-You may also wish to set some of the other GDAL options like this::
+You may wish to set some of the other GDAL options like this::
 
     GDAL_DATA: "/opt/python/share/gdal"
     PROJ_LIB: "/opt/python/share/proj"

--- a/layers/cibo/Makefile
+++ b/layers/cibo/Makefile
@@ -18,22 +18,25 @@
 
 PYTHON_VERSION := $(shell python3 -c 'import sys;print("{}.{}".format(sys.version_info[0], sys.version_info[1]))')
 
-NUMPY_VERSION:=1.26.4
-SQLITE_VERSION:=3450200
-TIFF_VERSION:=4.5.1
-PROJ_VERSION:=9.3.1
-GEOS_VERSION:=3.12.1
-GDAL_VERSION:=3.8.4
+NUMPY_VERSION:=2.1.0
+SQLITE_VERSION:=3490100
+SQLITE_YEAR:=2025
+TIFF_VERSION:=4.7.0
+PROJ_VERSION:=9.6.0
+GEOS_VERSION:=3.13.1
+GDAL_VERSION:=3.10.3
 
 export LD_LIBRARY_PATH := $(ARTIFACTS_DIR)/python/lib:$(ARTIFACTS_DIR)/python/lib64:${LD_LIBRARY_PATH}
 export PATH := $(ARTIFACTS_DIR)/python/bin:${PATH}
 export PYTHONPATH := $(ARTIFACTS_DIR)/python/lib/python$(PYTHON_VERSION)/site-packages
+# This seems to be where everything is installed (?)
+LIB_DIR:=/opt/python/lib
 
 build-CiboTilerLayer: prereqs pip numpy sqlite tiff proj geos gdal clean
 
 prereqs:
 	dnf install -y automake zlib-devel gcc gcc-c++ \
-         wget tar zip bzip2 swig make cmake libcurl-devel patch
+         wget tar zip bzip2 swig make cmake libcurl-devel patch patchelf
 	dnf clean all
 
 pip:
@@ -62,10 +65,10 @@ numpy:
 
 sqlite:
 	cd /tmp
-	wget -q https://www.sqlite.org/2024/sqlite-autoconf-$(SQLITE_VERSION).tar.gz
+	wget -q https://www.sqlite.org/$(SQLITE_YEAR)/sqlite-autoconf-$(SQLITE_VERSION).tar.gz
 	tar xf sqlite-autoconf-$(SQLITE_VERSION).tar.gz
 	cd sqlite-autoconf-$(SQLITE_VERSION)
-	CFLAGS="-O2 -Wl,-S" ./configure --enable-static=no --prefix=$(ARTIFACTS_DIR)/python
+	CFLAGS="-O2 -Wl,-S" ./configure --disable-static --prefix=$(ARTIFACTS_DIR)/python
 	make -j2 && make install
 	cd ..
 	rm -rf sqlite-autoconf-$(SQLITE_VERSION).tar.gz sqlite-autoconf-$(SQLITE_VERSION)
@@ -78,6 +81,7 @@ tiff:
 	mkdir -p build
 	cd build
 	cmake -D cxx=OFF -D CMAKE_BUILD_TYPE=MinSizeRel -D CMAKE_PREFIX_PATH=$(ARTIFACTS_DIR)/python \
+	  -DCMAKE_INSTALL_RPATH=$(LIB_DIR) \
 	  -D CMAKE_INSTALL_PREFIX=$(ARTIFACTS_DIR)/python -D CMAKE_INSTALL_LIBDIR=lib .. 2>&1
 	make -j2 && make install
 	cd ../..
@@ -91,7 +95,7 @@ proj:
 	mkdir build
 	cd build
 	cmake -D CMAKE_BUILD_TYPE=MinSizeRel -D CMAKE_PREFIX_PATH=$(ARTIFACTS_DIR)/python \
-	  -D BUILD_TESTING=OFF \
+	  -D BUILD_TESTING=OFF -DCMAKE_INSTALL_RPATH=$(LIB_DIR) \
 	  -D CMAKE_INSTALL_PREFIX=$(ARTIFACTS_DIR)/python -D CMAKE_INSTALL_LIBDIR=lib .. 2>&1
 	make -j2 && make install
 	cd ../..
@@ -105,8 +109,8 @@ geos:
 	mkdir build
 	cd build
 	cmake -D CMAKE_BUILD_TYPE=MinSizeRel -D CMAKE_PREFIX_PATH=$(ARTIFACTS_DIR)/python \
-	  -D BUILD_TESTING=OFF \
-	  -D CMAKE_INSTALL_PREFIX=$(ARTIFACTS_DIR)/python \ -DCMAKE_INSTALL_LIBDIR=lib .. 2>&1
+	  -D BUILD_TESTING=OFF -DCMAKE_INSTALL_RPATH=$(LIB_DIR) \
+	  -D CMAKE_INSTALL_PREFIX=$(ARTIFACTS_DIR)/python -DCMAKE_INSTALL_LIBDIR=lib .. 2>&1
 	make -j2 2>&1
 	make install
 	cd ../..
@@ -122,11 +126,17 @@ gdal:
 	cmake -DGDAL_BUILD_OPTIONAL_DRIVERS=OFF -DOGR_BUILD_OPTIONAL_DRIVERS=OFF -DGDAL_ENABLE_DRIVER_PNG=ON \
 	  -DGDAL_USE_PNG_INTERNAL=ON -DCMAKE_PREFIX_PATH=$(ARTIFACTS_DIR)/python \
 	  -DCMAKE_INSTALL_PREFIX=$(ARTIFACTS_DIR)/python -DCMAKE_BUILD_TYPE=MinSizeRel \
-	  -DCMAKE_INSTALL_LIBDIR=lib -DPython_ROOT=/var/lang .. 2>&1
+	  -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_RPATH=$(LIB_DIR) .. 2>&1
 	make -j2 2>&1
 	make install
 	cd ../..
 	rm -rf gdal-$(GDAL_VERSION).tar.gz gdal-$(GDAL_VERSION)
+	# https://github.com/OSGeo/gdal/issues/10432
+	patchelf --set-rpath /opt/python/lib $(ARTIFACTS_DIR)/python/lib/python$(PYTHON_VERSION)/site-packages/osgeo/*.so
+	# For some reason the actual location of sqlite gets written (under /tmp/samcli/artifacts)
+	# rather than the rpath we asked for. Rewrite it.
+	# Do this now because doing it earlier breaks GDAL's linking
+	patchelf --remove-needed $(ARTIFACTS_DIR)/python/lib/libsqlite3.so --add-needed /opt/python/lib/libsqlite3.so $(ARTIFACTS_DIR)/python/lib/libproj.so
 
 clean:
 	# Flag fancy stripping of .py files (and just using pyc) for now

--- a/layers/cibo/cibotiler/tiling.py
+++ b/layers/cibo/cibotiler/tiling.py
@@ -175,7 +175,7 @@ def getTile(filename, z, x, y, bands=None, rescaling=None, colormap=None,
 
             else:
                 if len(rescaling) != len(bands):
-                    raise ValueError("length of rescaling doesn't math number of bands")
+                    raise ValueError("length of rescaling doesn't match number of bands")
                 for n, (minVal, maxVal) in enumerate(rescaling):
                     minMaxRange = maxVal - minVal
                     rescaleddata = (data[n].astype(float) - minVal).clip(min=0) * (maxOutVal / minMaxRange)
@@ -394,7 +394,7 @@ def getTileMosaic(filenames, z, x, y, bands=None, rescaling=None, colormap=None,
 
             else:
                 if len(rescaling) != len(bands):
-                    raise ValueError("length of rescaling doesn't math number of bands")
+                    raise ValueError("length of rescaling doesn't match number of bands")
                 for data, dataslice, nodataForBands in results:
                     for n, (minVal, maxVal) in enumerate(rescaling):
                         minMaxRange = maxVal - minVal

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -63,7 +63,7 @@ stack_name = "cibo-tilerlayer-dev"
 [dev.build.parameters]
 cached = true
 parallel = true
-build_image = "public.ecr.aws/sam/build-python3.12:latest-arm64"
+build_image = "public.ecr.aws/sam/build-python3.12:1.136-arm64"
 use_container = true
 
 [dev.deploy.parameters]
@@ -98,7 +98,7 @@ stack_name = "cibo-tilerlayer-prod"
 [prod.build.parameters]
 cached = true
 parallel = true
-build_image = "public.ecr.aws/sam/build-python3.12:latest-arm64"
+build_image = "public.ecr.aws/sam/build-python3.12:1.136-arm64"
 use_container = true
 
 

--- a/template.yaml
+++ b/template.yaml
@@ -107,7 +107,7 @@ Resources:
           POWERTOOLS_SERVICE_NAME: PowertoolsOziusAPI
           POWERTOOLS_METRICS_NAMESPACE: API
           POWERTOOLS_LOG_LEVEL: INFO
-          LD_LIBRARY_PATH: "/opt/python/lib:/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/opt/lib"
+          #LD_LIBRARY_PATH: "/opt/python/lib:/var/lang/lib:/lib64:/usr/lib64:/var/runtime:/var/runtime/lib:/var/task:/opt/lib"
           GDAL_DATA: "/opt/python/share/gdal"
           PROJ_LIB: "/opt/python/share/proj"
           GDAL_CACHEMAX: "75%"

--- a/tilertest/app.py
+++ b/tilertest/app.py
@@ -59,11 +59,6 @@ POINTS = [(0, [255, 255, 255, 255]), (1, [215, 25, 28, 255]),
     (300, [8, 96, 9, 255]), (400, [14, 39, 17, 255]), 
     (700, [255, 0, 255, 255]), (1000, [148, 33, 225, 255])]
 
-# If this assert fails then there is something wrong with 
-# your SAM install. Try installing locally (in your home dir).
-LD_PATH = os.getenv('LD_LIBRARY_PATH')
-assert LD_PATH.startswith('/opt/python/lib')
-
 app = APIGatewayRestResolver()
 logger = Logger()
 metrics = Metrics(namespace="Powertools")


### PR DESCRIPTION
so `LD_LIBRARY_PATH` not required to be set.
Issues with always using the latest build image - good to have it fixed.